### PR TITLE
Fix broken internal link to Mock1.pdf in TSPL 2019

### DIFF
--- a/courses/TSPL/2019/tspl2019.md
+++ b/courses/TSPL/2019/tspl2019.md
@@ -126,7 +126,7 @@ For instructions on how to set up Agda for PLFA see [Getting Started](/GettingSt
 * [Assignment 2](/TSPL/2019/Assignment2/) cw2 due 4pm Thursday 17 October (Week 5)
 * [Assignment 3](/TSPL/2019/Assignment3/) cw3 due 4pm Thursday 31 October (Week 7)
 * [Assignment 4](/TSPL/2019/Assignment4/) cw4 due 4pm Thursday 14 November (Week 9)
-* [Assignment 5](/TSPL/2019/Mock1.pdf) cw5 due 4pm Thursday 21 November (Week 10)
+* [Assignment 5](https://plfa.inf.ed.ac.uk/TSPL/2019/Mock1.pdf) cw5 due 4pm Thursday 21 November (Week 10)
 
   Use file [Exam](/TSPL/2019/Exam/). Despite the rubric, do **all three questions**.
 


### PR DESCRIPTION
## Summary

- The PDF `Mock1.pdf` was removed from the Chinese fork when TSPL content was cut (commit `ea93e233`), but the link in `courses/TSPL/2019/tspl2019.md` remained, causing HTML-Proofer CI failures
- Updated the link to point back to the English site (`https://plfa.inf.ed.ac.uk/TSPL/2019/Mock1.pdf`)

## Test plan

- [x] CI HTML-Proofer check passes (no broken internal links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)